### PR TITLE
Add Python protobuf build and setup.py install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+*_pb2.py
+*.pyc
+build/
+w3dclientprotocol/__init__.py
+dist/
+w3dclientprotocol.egg-info/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+*.lock
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/build/
+docsrc/build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+./env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # W3Droid
+W3Droid is a API for Warcraft III which provides full external control of Warcraft III.
+
+This API exposes functionality for developing software for:
+
+- Machine-learning based bots
+
+The API provides a local websocket server to which a client can connect. The protocol used is https://developers.google.com/protocol-buffers. Utilize the .proto files in /w3d-clientprotocol to implement a client using this protocol.
+
+To run the API, download the latest Windows Release in the Releases section and execute it. (Currently no Release published - stay tuned!)

--- a/install_protoc.sh
+++ b/install_protoc.sh
@@ -1,0 +1,6 @@
+# PROTOC_ZIP=protoc-3.19.0-linux-x86_64.zip
+PROTOC_ZIP=protoc-21.5-linux-x86_64.zip
+curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.5/$PROTOC_ZIP
+sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
+sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
+rm -f $PROTOC_ZIP

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,81 @@
+"""Module setuptools script based off sc2client-proto."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from setuptools import setup
+from setuptools.command.install import install
+from setuptools.command.develop import develop
+from setuptools.command.egg_info import egg_info
+from shutil import which
+
+
+SETUP_DIR = Path(__file__).parent
+PROTO_DIR = SETUP_DIR / "w3dclientprotocol"
+
+try:
+    protoc = os.environ["PROTOC"]
+except KeyError:
+    protoc = which("protoc")
+if protoc is None or not Path(protoc).exists():
+    raise RuntimeError(
+        "protoc executable not found! Try debugging your protoc installation, or " \
+        "run ./install_protoc.sh or apt-get install -y protobuf-compiler"
+    )
+
+
+def compile_proto(source: str, python_out: str, proto_path: str):
+    """Invoke Protocol Compiler to generate python from given source .proto."""
+    if not protoc:
+        sys.exit('protoc not found. Is the protobuf-compiler installed?\n')
+
+    protoc_command = [
+        protoc,
+        '--proto_path', proto_path,
+        '--python_out', python_out,
+        source,
+    ]
+    
+    if subprocess.call(protoc_command) != 0:
+        sys.exit(
+            "protoc protobuf compilation failed. Ensure protoc is version >= 2.6. " \
+            "You can use a custom protoc by setting the PROTOC environment variable."
+        )
+
+def build_proto():
+    for proto_file in PROTO_DIR.rglob("*.proto"):
+        compile_proto(str(proto_file), str(SETUP_DIR), str(SETUP_DIR))
+    (PROTO_DIR / "__init__.py").touch()
+
+class ProtoInstallCommand(install):
+    def run(self):
+        build_proto()
+        install.run(self)
+
+
+class ProtoDevelopCommand(develop):
+    def run(self):
+        build_proto()
+        develop.run(self)
+
+
+class ProtoEggInfoCommand(egg_info):
+    def run(self):
+        build_proto()
+        egg_info.run(self)
+
+setup(
+    name="w3dclientprotocol",
+    version="0.0.1",
+    description="Warcraft III API - client protocol",
+    license="MIT",
+    url="https://github.com/W3Droid/w3droid",
+    packages=["w3dclientprotocol"],
+    install_requires=["protobuf"],
+    cmdclass={
+        'install': ProtoInstallCommand,
+        'develop': ProtoDevelopCommand,
+        'egg_info': ProtoEggInfoCommand,
+    },
+)

--- a/w3dclientprotocol/common.proto
+++ b/w3dclientprotocol/common.proto
@@ -1,0 +1,37 @@
+
+syntax = "proto2";
+
+package W3DroidAPIProtocol;
+
+
+// Point on the screen/minimap (e.g., 0..64).
+// Note: bottom left of the screen is 0, 0.
+message PointI {
+  optional int32 x = 1;
+  optional int32 y = 2;
+}
+
+// Point on the game board, 0..255.
+// Note: bottom left of the screen is 0, 0.
+message Point2D {
+  optional float x = 1;
+  optional float y = 2;
+}
+
+// Point on the game board, 0..255.
+// Note: bottom left of the screen is 0, 0.
+message Point {
+  optional float x = 1;
+  optional float y = 2;
+  optional float z = 3;
+}
+
+// Screen dimensions.
+message Size2DI {
+  optional int32 x = 1;
+  optional int32 y = 2;
+}
+
+
+
+

--- a/w3dclientprotocol/error.proto
+++ b/w3dclientprotocol/error.proto
@@ -1,0 +1,10 @@
+
+syntax = "proto2";
+
+package W3DroidAPIProtocol;
+
+enum ActionResult {
+  Success = 1;
+  NotSupported = 2;
+  Error = 3;
+}

--- a/w3dclientprotocol/raw.proto
+++ b/w3dclientprotocol/raw.proto
@@ -1,0 +1,52 @@
+
+syntax = "proto2";
+
+package W3DroidAPIProtocol;
+
+import "w3dclientprotocol/common.proto";
+
+//
+// Observation
+//
+
+message ObservationRaw {
+  repeated Unit units = 2;
+}
+
+message Unit {
+  optional uint64 tag = 3;                  // Unique identifier for a unit
+  optional uint32 unit_type = 4;
+  optional int32 owner = 5;
+
+  optional Point pos = 6;
+
+  optional float health = 14;
+  optional float health_max = 15;
+  optional float mana = 17;
+  optional float mana_max = 37;
+}
+
+//
+// Action
+//
+
+message ActionRaw {
+  oneof action {
+    ActionRawUnitCommand unit_command = 1;
+  }
+}
+
+enum AbilityEnum {
+  Move = 1;
+  Attack = 2;
+}
+
+
+message ActionRawUnitCommand {
+  optional AbilityEnum ability_id = 1;
+  oneof target {
+    Point2D target_world_space_pos = 2;
+    uint64 target_unit_tag = 3;
+  }
+  repeated uint64 unit_tags = 4;
+}

--- a/w3dclientprotocol/w3droidapi.proto
+++ b/w3dclientprotocol/w3droidapi.proto
@@ -1,0 +1,75 @@
+
+syntax = "proto2";
+
+package W3DroidAPIProtocol;
+
+import "w3dclientprotocol/error.proto";
+import "w3dclientprotocol/raw.proto";
+
+//
+// Request/Response
+//
+
+message Request {
+  oneof request {
+    // During Game
+    RequestObservation observation = 10;        // Snapshot of the current game state.
+    RequestAction action = 11;                  // Executes an action for a participant.
+
+    // Debugging
+    RequestPing ping = 19;                      // Network ping for testing connection.
+  }
+  optional uint32 id = 97;
+}
+
+message Response {
+  oneof response {
+    // During Game
+    ResponseObservation observation = 10;
+    ResponseAction action = 11;
+
+    // Debugging
+    ResponsePing ping = 19;
+  }
+  optional uint32 id = 97;
+  repeated string error = 98;                   // If command is missing, this will contain the error. Otherwise this will contain any warnings.
+}
+
+//-----------------------------------------------------------------------------
+message RequestObservation {
+}
+
+message ResponseObservation {
+  optional Observation observation = 3;
+}
+
+//-----------------------------------------------------------------------------
+message RequestAction {
+   repeated Action actions = 1;
+}
+
+message ResponseAction {
+   repeated ActionResult result = 1;
+}
+
+
+//-----------------------------------------------------------------------------
+message RequestPing {
+}
+
+message ResponsePing {
+  optional string game_version = 1;
+  optional string data_version = 2;
+  optional uint32 data_build = 3;
+  optional uint32 base_build = 4;
+}
+
+
+message Observation {
+  optional ObservationRaw raw_data = 5;                     // Populated if Raw interface is enabled.
+}
+
+message Action {
+  optional ActionRaw action_raw = 1;                        // Populated if Raw interface is enabled.
+}
+


### PR DESCRIPTION
This PR mimics the build process for [sc2clientprotocol](https://github.com/Blizzard/s2client-proto) with some minor improvements from deepmind's base installation and some additional changes to the w3droid repo code, allowing us to load the protobufs in python after installation using pip.

## Changes
 
The additional changes in this PR includes:
- Adding a Python .gitignore template that also has .gitignore lines matching sc2clientprotocol
- Adding an install_protoc.sh file for manual installation of the protoc protobuf compiler for a user, if required.
- Renaming w3d-clientprotocol to w3dclientprotocol mainly for nicer syntax in Python imports.
- Enabling Python installation with Pip using setup.py and with a custom command setup for protobuf compilation

## Install

To install this package in Python, simply activate your virtual environment of choice and then run `pip install .` inside the w3droid directory. When this package is closer to complete, we can publish it to PyPi so that we can run `pip install w3dclientprotocol`.


When this package is installed in Python, we rely on the protoc protobuf compiler to convert the various .proto files into importable Python modules that can be used for Python development. Note that we assume that protoc is already installed by the user, but if not, we provide a simple install_protoc.sh script for manual installation on Linux, if required. Do not assume that this script will work in all cases, and we recommend users ensure they install and debug protoc themselves via their preferred installer.

## Usage

After installation, the following code here: https://github.com/deepmind/pysc2/blob/master/pysc2/lib/features.py#L31 would look like the following in the context of w3droid:

```
from w3dclientprotocol import raw_pb2 as w3d_raw
from w3dclientprotocol import w3dapi_pb2 as w3d_api
```